### PR TITLE
dont use nonexisting hashes

### DIFF
--- a/src/pdm_download/command.py
+++ b/src/pdm_download/command.py
@@ -166,13 +166,13 @@ def _get_file_hashes(
                 )
                 if match_hash:
                     can_hashes.remove(match_hash)
-                hashes.append(
-                    {
-                        "url": package.link.url_without_fragment,
-                        "file": filename,
-                        "hash": match_hash["hash"],
-                    }
-                )
+                    hashes.append(
+                        {
+                            "url": package.link.url_without_fragment,
+                            "file": filename,
+                            "hash": match_hash["hash"],
+                        }
+                    )
 
             for item in can_hashes:
                 project.core.ui.echo(


### PR DESCRIPTION
Hi Frost Ming,

There apears to be an issue with how "non True" hashes are treated.

Non True match_hash'es are not removed from the can_hashes, but their hash value is still added to the hashes.

This can not work as the "Non True" match_hash can not have a hash member.

I believe this issue is zipapp independent...
